### PR TITLE
More robust comment handling in mtl files

### DIFF
--- a/src/mtl.rs
+++ b/src/mtl.rs
@@ -235,10 +235,12 @@ impl Mtl {
                         m.map_bump = parser.get_string();
                     }
                 }
-                Some("#") | None => {}
-                other => {
-                    panic!("unhandled mtl: {:?}", other);
+                Some(other) => {
+                    if !other.starts_with("#") {
+                        panic!("unhandled mtl: {:?}", other);
+                    }
                 }
+                None => {}
             }
         }
 


### PR DESCRIPTION
The mtl-parser crashes if a file contains a comment without a space after the leading `#`, for example:
```
## This line crashes the parser
```
This patch fixes the problem, the same way it is already fixed in the obj-file parser.