### PR TITLE
Panic Safety and Mild Cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 extern crate genmesh;
 
 pub use mtl::{Material, Mtl};
-pub use obj::{GenPolygon, Group, IndexTuple, Obj, Object, SimplePolygon};
+pub use obj::{GenPolygon, Group, IndexTuple, Obj, Object, SimplePolygon, ObjError};
 
 mod obj;
 mod mtl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 #[cfg(feature = "genmesh")]
 extern crate genmesh;
 
-pub use mtl::{Material, Mtl};
+pub use mtl::{Material, Mtl, MtlError, MtlMissingType};
 pub use obj::{GenPolygon, Group, IndexTuple, Obj, Object, SimplePolygon, ObjError};
 
 mod obj;

--- a/src/mtl.rs
+++ b/src/mtl.rs
@@ -70,20 +70,29 @@ impl Material {
     }
 }
 
+/// Indicates type of a missing value
 #[derive(Debug)]
-pub enum MissingType {
+pub enum MtlMissingType {
+    /// i32
     Tyi32,
+    /// f32
     Tyf32,
+    /// String
     TyString,
 }
 
+/// Errors parsing or loading a .mtl file.
 #[derive(Debug)]
 pub enum MtlError {
     IoError(io::Error),
+    /// Given instruction was not in .mtl spec.
     InvalidInstruction(String),
+    /// Attempted to parse value, but failed.
     InvalidValue(String),
+    /// `newmtl` issued, but no name provided.
     MissingMaterialName,
-    MissingValue(MissingType),
+    /// Instruction requires a value, but that value was not provided.
+    MissingValue(MtlMissingType),
 }
 
 impl From<io::Error> for MtlError {
@@ -122,7 +131,7 @@ impl<'a, I: Iterator<Item = &'a str>> Parser<I> {
         match self.0.next() {
             Some(v) => FromStr::from_str(v).map_err(|_| MtlError::InvalidValue(v.to_string())),
             None => {
-                Err(MtlError::MissingValue(MissingType::Tyi32))
+                Err(MtlError::MissingValue(MtlMissingType::Tyi32))
             }
         }
     }
@@ -131,7 +140,7 @@ impl<'a, I: Iterator<Item = &'a str>> Parser<I> {
         match self.0.next() {
             Some(v) => FromStr::from_str(v).map_err(|_| MtlError::InvalidValue(v.to_string())),
             None => {
-                Err(MtlError::MissingValue(MissingType::Tyf32))
+                Err(MtlError::MissingValue(MtlMissingType::Tyf32))
             }
         }
     }
@@ -147,7 +156,7 @@ impl<'a, I: Iterator<Item = &'a str>> Parser<I> {
                 }))
             },
             None => {
-                Err(MtlError::MissingValue(MissingType::TyString))
+                Err(MtlError::MissingValue(MtlMissingType::TyString))
             }
         }
     }

--- a/src/mtl.rs
+++ b/src/mtl.rs
@@ -74,17 +74,17 @@ impl Material {
 #[derive(Debug)]
 pub enum MtlMissingType {
     /// i32
-    Tyi32,
+    I32,
     /// f32
-    Tyf32,
+    F32,
     /// String
-    TyString,
+    String,
 }
 
 /// Errors parsing or loading a .mtl file.
 #[derive(Debug)]
 pub enum MtlError {
-    IoError(io::Error),
+    Io(io::Error),
     /// Given instruction was not in .mtl spec.
     InvalidInstruction(String),
     /// Attempted to parse value, but failed.
@@ -97,7 +97,7 @@ pub enum MtlError {
 
 impl From<io::Error> for MtlError {
     fn from(e: Error) -> Self {
-        Self::IoError(e)
+        Self::Io(e)
     }
 }
 
@@ -111,7 +111,7 @@ impl<'a> From<Material> for Cow<'a, Material> {
 struct Parser<I>(I);
 
 impl<'a, I: Iterator<Item = &'a str>> Parser<I> {
-    fn get_vec(mut self) -> Result<[f32; 3], MtlError> {
+    fn get_vec(&mut self) -> Result<[f32; 3], MtlError> {
         let (x, y, z) = match (self.0.next(), self.0.next(), self.0.next()) {
             (Some(x), Some(y), Some(z)) => (x, y, z),
             other => {
@@ -127,20 +127,20 @@ impl<'a, I: Iterator<Item = &'a str>> Parser<I> {
         }
     }
 
-    fn get_i32(mut self) -> Result<i32, MtlError> {
+    fn get_i32(&mut self) -> Result<i32, MtlError> {
         match self.0.next() {
             Some(v) => FromStr::from_str(v).map_err(|_| MtlError::InvalidValue(v.to_string())),
             None => {
-                Err(MtlError::MissingValue(MtlMissingType::Tyi32))
+                Err(MtlError::MissingValue(MtlMissingType::I32))
             }
         }
     }
 
-    fn get_f32(mut self) -> Result<f32, MtlError> {
+    fn get_f32(&mut self) -> Result<f32, MtlError> {
         match self.0.next() {
             Some(v) => FromStr::from_str(v).map_err(|_| MtlError::InvalidValue(v.to_string())),
             None => {
-                Err(MtlError::MissingValue(MtlMissingType::Tyf32))
+                Err(MtlError::MissingValue(MtlMissingType::F32))
             }
         }
     }
@@ -156,7 +156,7 @@ impl<'a, I: Iterator<Item = &'a str>> Parser<I> {
                 }))
             },
             None => {
-                Err(MtlError::MissingValue(MtlMissingType::TyString))
+                Err(MtlError::MissingValue(MtlMissingType::String))
             }
         }
     }
@@ -177,7 +177,7 @@ impl Mtl {
         for line in file.lines() {
             let mut parser = match line {
                 Ok(ref line) => Parser(line.split_whitespace().filter(|s| !s.is_empty())),
-                Err(err) => return Err(MtlError::IoError(err)),
+                Err(err) => return Err(MtlError::Io(err)),
             };
             match parser.0.next() {
                 Some("newmtl") => {

--- a/src/mtl.rs
+++ b/src/mtl.rs
@@ -145,7 +145,7 @@ impl<'a, I: Iterator<Item = &'a str>> Parser<I> {
         }
     }
 
-    fn get_string(mut self) -> Result<String, MtlError> {
+    fn into_string(mut self) -> Result<String, MtlError> {
         match self.0.next() {
             Some(v) => {
                 // See note on mtllib parsing in obj.rs for why this is needed/works
@@ -241,32 +241,32 @@ impl Mtl {
                 }
                 Some("map_Ka") => {
                     if let Some(ref mut m) = material {
-                        m.map_ka = Some(parser.get_string()?);
+                        m.map_ka = Some(parser.into_string()?);
                     }
                 }
                 Some("map_Kd") => {
                     if let Some(ref mut m) = material {
-                        m.map_kd = Some(parser.get_string()?);
+                        m.map_kd = Some(parser.into_string()?);
                     }
                 }
                 Some("map_Ks") => {
                     if let Some(ref mut m) = material {
-                        m.map_ks = Some(parser.get_string()?);
+                        m.map_ks = Some(parser.into_string()?);
                     }
                 }
                 Some("map_d") => {
                     if let Some(ref mut m) = material {
-                        m.map_d = Some(parser.get_string()?);
+                        m.map_d = Some(parser.into_string()?);
                     }
                 }
                 Some("map_refl") => {
                     if let Some(ref mut m) = material {
-                        m.map_refl = Some(parser.get_string()?);
+                        m.map_refl = Some(parser.into_string()?);
                     }
                 }
                 Some("map_bump") | Some("map_Bump") | Some("bump") => {
                     if let Some(ref mut m) = material {
-                        m.map_bump = Some(parser.get_string()?);
+                        m.map_bump = Some(parser.into_string()?);
                     }
                 }
                 Some(other) => {

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -60,7 +60,7 @@ impl GenPolygon for Polygon<IndexTuple> {
 /// Errors parsing or loading a .obj file.
 #[derive(Debug)]
 pub enum ObjError {
-    IoError(io::Error),
+    Io(io::Error),
     /// One of the arguments to `f` is malformed.
     MalformedFaceGroup {
         line_number: usize,
@@ -86,12 +86,12 @@ pub enum ObjError {
     GenMeshTooManyVertsInPolygon{
         line_number: usize,
         vert_count: usize,
-    }
+    },
 }
 
 impl From<io::Error> for ObjError {
     fn from(e: Error) -> Self {
-        Self::IoError(e)
+        Self::Io(e)
     }
 }
 
@@ -300,7 +300,7 @@ where
             let (line, mut words) = match line {
                 Ok(ref line) => (line.clone(), line.split_whitespace().filter(|s| !s.is_empty())),
                 Err(err) => {
-                    return Err(ObjError::IoError(io::Error::new(io::ErrorKind::InvalidData, format!("failed to readline {}", err))));
+                    return Err(ObjError::Io(io::Error::new(io::ErrorKind::InvalidData, format!("failed to readline {}", err))));
                 }
             };
             let first = words.next();

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -57,24 +57,31 @@ impl GenPolygon for Polygon<IndexTuple> {
     }
 }
 
+/// Errors parsing or loading a .obj file.
 #[derive(Debug)]
 pub enum ObjError {
     IoError(io::Error),
-    PoorlyFormedFaceGroup {
+    /// One of the arguments to `f` is malformed.
+    MalformedFaceGroup {
         line_number: usize,
         group: String,
     },
+    /// An argument list either has unparsable arguments or is
+    /// missing one or more arguments.
     ArgumentListFailure {
         line_number: usize,
         list: String,
     },
+    /// Command found that is not in the .obj spec.
     UnexpectedCommand {
         line_number: usize,
         command: String,
     },
+    /// `mtllib` command issued, but no name was specified.
     MissingMTLName {
         line_number: usize,
     },
+    /// [`genmesh::Polygon`] only supports triangles and squares.
     #[cfg(feature = "genmesh")]
     GenMeshTooManyVertsInPolygon{
         line_number: usize,
@@ -265,7 +272,7 @@ where
                               v.map(|v| normalize(v, self.texture.len())),
                               n.map(|n| normalize(n, self.normal.len()))))
             }
-            _ => Err(ObjError::PoorlyFormedFaceGroup {line_number, group: String::from(group)}),
+            _ => Err(ObjError::MalformedFaceGroup {line_number, group: String::from(group)}),
         }
     }
 

--- a/tests/load_obj_file.rs
+++ b/tests/load_obj_file.rs
@@ -20,5 +20,5 @@ use std::path::Path;
 #[test]
 fn load_test_file() {
     let mut sponza = Obj::<SimplePolygon>::load(&Path::new("test_assets/sponza.obj")).unwrap();
-    let _ = sponza.load_mtls();
+    let _ = sponza.load_mtls().unwrap();
 }


### PR DESCRIPTION
Resolves #11.

This PR removes all instances of panics where the user didn't ask for a panic. I've tested the tests and against my codebase using it, and everything seems still in order.

Notable changes
 - Added `ObjError`, `MtlError`, and `MtlMissingType`
 - Refactored `Obj::{parse_vertex, parse_texture, parse_normal}` to return their output instead of modifying state. Combined them into `parse_two` and `parse_three` to reduce duplicate code.
 - Added hack to allow filenames with spaces as the mtllib/texture names. (Explanation in comment)
 - Added private function `Obj::load_single_mtl` to make error handling more concise and remove duplicate code.

Breaking Changes:
 - Everything now returns a `ObjError` or `MtlError` instead of a `io::Error`
 - Neither `ObjError` nor `MtlError` implement `Display`. Should they?

Now that I've dug a bit into the codebase, there are a couple of improvements I still want to make. Feel free to comment on any of them 😄. Vaguely in order of importance:
 - Run rustfmt on the codebase & verify rustfmt in CI
 - Create function `Obj::load_mtl_fn` that takes a function which takes the base directory and the mtllib name and returns _something_ that `impl Read`. This will allow special file lookup or file loading if need be. `Obj::load_mtl` will just call `Obj::load_mtl_fn` with a function that uses how it currently resolves now. Will file an issue about this tmmr.
 - Document all the things.
 - Maybe implement #2.