### PR TITLE
Add `Obj::load_mtls_fn`

### DIFF
--- a/src/obj.rs
+++ b/src/obj.rs
@@ -52,7 +52,7 @@ impl GenPolygon for Polygon<IndexTuple> {
         match gs.len() {
             3 => Ok(Polygon::PolyTri(Triangle::new(gs[0], gs[1], gs[2]))),
             4 => Ok(Polygon::PolyQuad(Quad::new(gs[0], gs[1], gs[2], gs[3]))),
-            n => return Err(ObjError::GenMeshTooManyVertsInPolygon {line_number, vert_count}),
+            n => return Err(ObjError::GenMeshTooManyVertsInPolygon {line_number, vert_count: n}),
         }
     }
 }


### PR DESCRIPTION
Depends on #12. Only the last commit is relevant to this PR, will rebase once #12 is merged.

For complicated reasons, I need to be able to preprocess MTL files before the OBJ loader loads them. These files may also be at a different location than the obj loader expects. To facilitate this, I added a function `Obj::load_mtls_fn` that takes a callback which takes the base_path for the obj and the name of the mtl and returns something that implements `io::BufRead`

I don't think this should be a breaking change as the semantics and api of `Obj::load_mtls` should be identical (same code, just run with a layer of indirection) and adding a function is not a breaking change.