### PR TITLE
Expose the vec in simple polygon

### DIFF
--- a/src/obj.rs
+++ b/src/obj.rs
@@ -41,7 +41,7 @@ pub struct IndexTuple(pub usize, pub Option<usize>, pub Option<usize>);
 ///
 /// Each vertex has an associated tuple of `(position, texture, normal)` indices.
 #[derive(Debug, Clone, Hash, PartialEq)]
-pub struct SimplePolygon(Vec<IndexTuple>);
+pub struct SimplePolygon(pub Vec<IndexTuple>);
 
 pub trait WriteToBuf {
     type Error: std::fmt::Display;


### PR DESCRIPTION
This is a bug from the last PR, it should have been exposed, otherwise
there is no way to access the indices.

Edit: Alternatively we could expose the internals as an `indices` field to make it a bit more clear.