### PR TITLE
Add missing clone derives for Obj and ObjData

### DIFF
--- a/src/obj.rs
+++ b/src/obj.rs
@@ -342,7 +342,7 @@ impl Default for ObjData {
 
 /// A struct used to store `Obj` data as well as its source directory used to load the referenced
 /// .mtl files.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Obj {
     /// The data associated with this `Obj` file.
     pub data: ObjData,

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -313,7 +313,7 @@ impl WriteToBuf for Group {
 }
 
 /// The data model associated with each `Obj` file.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ObjData {
     /// Vertex positions.
     pub position: Vec<[f32; 3]>,


### PR DESCRIPTION
Another tiny PR adding missing clone derives for Obj and ObjData.