### PR TITLE
Add a strict parsing feature (enabled by default)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ name = "obj"
 path = "src/lib.rs"
 
 [features]
-default = ["strict"]
-strict = []
+default = []
 
 [dependencies]
 genmesh = { version = "0.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ name = "obj"
 path = "src/lib.rs"
 
 [features]
-default = []
+default = ["strict"]
+strict = []
 
 [dependencies]
 genmesh = { version = "0.6", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@
 //   limitations under the License.
 
 pub use self::mtl::{Material, Mtl, MtlError, MtlMissingType};
-pub use self::obj::{Group, IndexTuple, MtlLibsLoadError, Obj, ObjData, ObjError, ObjMaterial, Object, SimplePolygon};
+pub use self::obj::{
+    Group, IndexTuple, LoadConfig, MtlLibsLoadError, Obj, ObjData, ObjError, ObjMaterial, Object, SimplePolygon,
+};
 
 mod mtl;
 mod obj;

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -702,11 +702,12 @@ impl ObjData {
                 }
                 Some("s") => (),
                 Some("l") => (),
-                Some(other) => {
-                    if !other.starts_with('#') {
+                Some(_other) => {
+                    #[cfg(feature = "strict")]
+                    if !_other.starts_with('#') {
                         return Err(ObjError::UnexpectedCommand {
                             line_number: idx,
-                            command: other.to_string(),
+                            command: _other.to_string(),
                         });
                     }
                 }

--- a/tests/load_non_compliant_obj.rs
+++ b/tests/load_non_compliant_obj.rs
@@ -1,0 +1,83 @@
+//   Copyright 2017 GFX Developers
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+use obj::{LoadConfig, ObjData};
+use std::io::BufReader;
+
+/// This is an example of an obj file augmented with additional custom commands.
+/// We expect to be able to load the recognizable parts of these kinds of files.
+static SQUARE_EXTENDED: &'static str = "
+scale 1
+vt 0 0
+adjf 0 1
+vt 1 0
+adjf 0
+vt 1 1
+adjf 0 1
+vt 0 1
+adjf 1
+v 0 0 0.01
+ny 0 0 0
+adje 0 1 3
+v 1 0 0.01
+ny 1 0 0
+adje 1 2
+v 0 0.98480775301220813 0.18364817766693034
+ny 0 1 0
+adje 3 4
+v 1 0.98480775301220813 0.18364817766693034
+ny 1 1 0
+adje 0 2 4
+e 4 1
+e 1 2
+e 2 4
+e 3 1
+e 4 3
+f 4/3 1/1 2/2
+f 3/4 1/1 4/3
+";
+
+/// This is the strictly spec compliant version of `SQUARE_EXTENDED`.
+static SQUARE_STRICT: &'static str = "
+vt 0 0
+vt 1 0
+vt 1 1
+vt 0 1
+v 0 0 0.01
+v 1 0 0.01
+v 0 0.98480775301220813 0.18364817766693034
+v 1 0.98480775301220813 0.18364817766693034
+f 4/3 1/1 2/2
+f 3/4 1/1 4/3
+";
+
+#[test]
+fn load_square_non_compliant() {
+    let permissive_config = LoadConfig { strict: false };
+
+    // Load the extended version of the square
+    let mut reader = BufReader::new(SQUARE_EXTENDED.as_bytes());
+    let obj_ext = ObjData::load_buf_with_config(&mut reader, permissive_config).unwrap();
+
+    // Load the vanilla version of the square
+    let mut reader = BufReader::new(SQUARE_STRICT.as_bytes());
+    let obj_basic = ObjData::load_buf_with_config(&mut reader, permissive_config).unwrap();
+
+    assert_eq!(obj_basic, obj_ext);
+
+    let strict_config = LoadConfig { strict: true };
+
+    let mut reader = BufReader::new(SQUARE_EXTENDED.as_bytes());
+    assert!(ObjData::load_buf_with_config(&mut reader, strict_config).is_err());
+}


### PR DESCRIPTION
When enabled, strict will return an error when an obj contains a command
that is not in the spec.

The motivation for this change is that obj is simple enough to allow
others to easily extend it with domain specific commands. For instance
the ARCsim cloth solver extends objs with face adjacency data.

It is beneficial for casual users and researchers to be able to parse
such third party obj files.