### PR TITLE
fix: `impl std::fmt::Display for IndexTuple` is incorrect for normal without texture coordinate

### DIFF
--- a/src/obj.rs
+++ b/src/obj.rs
@@ -77,7 +77,15 @@ impl std::fmt::Display for IndexTuple {
             write!(f, "/{}", idx + 1)?;
         }
         if let Some(idx) = self.2 {
-            write!(f, "/{}", idx + 1)?;
+            if self.1.is_some() {
+                write!(f, "/{}", idx + 1)?;
+            } else {
+                // requires empty texture coordinate index
+                //
+                // reference:
+                // <https://en.wikipedia.org/wiki/Wavefront_.obj_file#Vertex_normal_indices_without_texture_coordinate_indices>
+                write!(f, "//{}", idx + 1)?;
+            }
         }
         Ok(())
     }

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -793,4 +793,14 @@ mod tests {
             Err(ObjError::ZeroVertexNumber { line_number: 2 })
         ));
     }
+
+    /// Test that [`std::fmt::Display`] is implemented correctly for
+    /// [`IndexTuple`].
+    #[test]
+    fn index_tuple_display() {
+        assert_eq!(IndexTuple(0, None, None).to_string(), "1");
+        assert_eq!(IndexTuple(0, Some(0), None).to_string(), "1/1");
+        assert_eq!(IndexTuple(0, Some(0), Some(0)).to_string(), "1/1/1");
+        assert_eq!(IndexTuple(0, None, Some(0)).to_string(), "1//1");
+    }
 }


### PR DESCRIPTION
When using `IndexTuple(0, None, Some(0))`, the output should be `1//1`
but the output was `1/1`.

`1/1` implies position index followed by texture coordinate index
where as `1//1` implies position index followed by no texture
coordinate index followed by normal index which is the expected
output.

## Reference
* https://en.wikipedia.org/wiki/Wavefront_.obj_file#Vertex_normal_indices_without_texture_coordinate_indices